### PR TITLE
Accomodated for 0 hours or 0 minutes in final answer

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -111,14 +111,19 @@
             }
 
             // Outputs final answer
-
             if (errorCheck === true) {
-                answer.innerHTML = '<p>Total time is ' + hourFinal + ' ' + hourOutput +
-            ' and ' + minuteFinal + ' ' + minuteOutput + '.' + '</p>';
+                if (hourFinal === 0) {
+                    answer.innerHTML = '<p>Total time is ' + minuteFinal + ' ' + minuteOutput + '.' + '</p>';
+                } else if (minuteFinal === 0) {
+                    answer.innerHTML = '<p>Total time is ' + hourFinal + ' ' + hourOutput + '.' + '</p>';
+                } else {
+                    answer.innerHTML = '<p>Total time is ' + hourFinal + ' ' + hourOutput +
+                ' and ' + minuteFinal + ' ' + minuteOutput + '.' + '</p>';
+                }                
             } else {
                 answer.innerHTML = '<p class="red-text">Please enter a valid number.</p>';
                 return false;
-            };
+            }
 
         e.preventDefault();
     };


### PR DESCRIPTION
Currently, if the final answer contains 0 hours, or 0 minutes, the output is:
_Total time is 0 hours and 20 minutes_ or _Total time is 2 hours and 0 minutes._

With this change, the output will now be:
_Total time is 20 minutes._ or _Total time is 2 hours._